### PR TITLE
Add php-ts-mode

### DIFF
--- a/codeium.el
+++ b/codeium.el
@@ -261,6 +261,7 @@
 		 (perl-mode . 28)
 		 (cperl-mode . 28)
 		 (php-mode . 29)
+  		 (php-ts-mode . 29)
 		 (text-mode . 30)
 		 (python-mode . 33)
 		 (python-ts-mode . 33)


### PR DESCRIPTION
Add support for [php-ts-mode](https://github.com/emacs-php/php-ts-mode). This package is not yet available in any ELPA, but will be submitted to GNU ELPA in due course.

refs https://github.com/emacs-php/php-ts-mode/issues/55