### PR TITLE
Extra completion-at-point function extensions for usability

### DIFF
--- a/codeium.el
+++ b/codeium.el
@@ -1139,7 +1139,8 @@ returns. Prefer using `codeium-request' directly instead.
 			(tmp (codeium-request-synchronously 'GetCompletions state nil))
 			(req (car tmp))
 			(res (cdr tmp))
-			(rst (and (not (input-pending-p)) (codeium-parse-getcompletions-res req res))))
+			(rst (and (not (input-pending-p)) (codeium-parse-getcompletions-res req res)))
+			(company-doc-buffer " *codeium-docs*"))
 		(cl-destructuring-bind (dmin dmax table completionids) rst
 			(let*
 				(
@@ -1156,12 +1157,49 @@ returns. Prefer using `codeium-request' directly instead.
 						(string=
 							(buffer-substring-no-properties rmin rmax)
 							(substring-no-properties buffer-prev-str pmin pmax)))
-					(list rmin rmax table :exit-function
-						(lambda (string status)
-							(when-let ((num (and (eq status 'finished) (cl-position string table :test 'string=))))
-								(codeium-request 'AcceptCompletion state
-									`((codeium/completion_id . ,(nth num completionids)))
-									#'ignore))))))))
+					(list rmin rmax table
+					      :exit-function
+					      `(lambda (string status)
+						 (ignore-errors (kill-buffer ,company-doc-buffer))
+						 (when-let* ((num (and (eq status 'finished) (cl-position string ',table :test 'string=))))
+						   (codeium-request 'AcceptCompletion ,state
+								    `((codeium/completion_id . ,(nth num ',completionids)))
+								    #'ignore)))
+					      :annotation-function
+					      (lambda (_)
+						  (propertize
+						   " Codium"
+						   'face font-lock-comment-face))
+					      :company-kind
+					      (lambda (_) 'magic)
+					      :company-doc-buffer
+					      `(lambda (string)
+						 ;; Soft load of markdown-mode, if no package then will show doc in plain text
+						 (unless (featurep 'markdown-mode)
+						   (ignore-errors (require 'markdown-mode)))
+						 (let* ((derived-lang (or (if (boundp 'markdown-code-lang-modes)
+									      (car (rassoc major-mode
+											   markdown-code-lang-modes)))
+									  (replace-regexp-in-string
+									   "\\(/.*\\|-ts-mode\\|-mode\\)$" ""
+									   (substring-no-properties mode-name))))
+							(markdown-fontify-code-blocks-natively t)
+							(inhibit-read-only t)
+							(non-essential t)
+							(delay-mode-hooks t))
+						   (with-current-buffer (get-buffer-create ,company-doc-buffer t)
+						     (erase-buffer)
+						     (if (fboundp 'gfm-view-mode)
+							 (progn
+							   (ignore-errors (funcall 'gfm-view-mode))
+							   (insert (concat "Codeium: " derived-lang "\n"
+									   "*****\n"
+									   "```" (downcase derived-lang) "\n"
+									   string "\n"
+									   "```")))
+						       (insert string))
+						     (font-lock-ensure (point-min) (point-max))
+						     (current-buffer)))))))))
 	;; (error
 	;; 	(message "an error occurred in codeium-completion-at-point: %s" (error-message-string err))
 	;; 	nil)

--- a/codeium.el
+++ b/codeium.el
@@ -1168,7 +1168,7 @@ returns. Prefer using `codeium-request' directly instead.
 					      :annotation-function
 					      (lambda (_)
 						  (propertize
-						   " Codium"
+						   " Codeium"
 						   'face font-lock-comment-face))
 					      :company-kind
 					      (lambda (_) 'magic)


### PR DESCRIPTION
* Added :company-doc-buffer function, to show full completion text which includes markdown where available to pretty up the doc
* Added :company-kind to show "magic" icon indicator.
* Added :company-annotation in order to show capf source in disp
* Made a few small edits to :exit-function that did not appear to have correct lexical binds.

Here is result on my machine using corfu/cape as the capf front-end.

<img width="879" alt="image" src="https://github.com/Exafunction/codeium.el/assets/6047093/fe9ad813-6a7c-4189-baa3-4f609cc556b6">

Item `#8` in the list is high-lighted, and to the right the help document displays showing the full completion text in markdown using buffer language (python here) for the font-lock.  If markdown is not installed, plain text will be shown but still with line breaks vs. how displays in listing on one-line.

There is also a magic wand icon to the left of Codeium completion, that gives indicator it is from Codeium completion.  And (if the completion text wasn't so long in this example) would also show `Codeium` on the left for the annotation.