### PR TITLE
Search auth-source for api key before authn

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ the full response of a `GetCompletions` request:
 Note that, among other things, you get probabilities for each token!
 We would love to see a PR or your own package that uses those!
 
+### 🔓 Authentication
+If you want to authenticate automatically, add your codeium api key to one of `auth-sources`. For example
+
+~/.authinfo.gpg:
+``` text
+machine codeium.com login apikey secret <insert_api_key_here>
+```
+
 ## 💾 Installation Options
 
 ### ➡️ straight.el

--- a/codeium.el
+++ b/codeium.el
@@ -184,10 +184,12 @@
 ;; for AcceptCompletion
 (codeium-def codeium/completion_id (_api _state val) val)
 
-;; alternative getting key from file?
-;; TODO
-;; (setq codeium/metadata/api_key 'codeium-default/metadata/api_key)
-(defun codeium-get-saved-api-key ())
+(defun codeium-get-saved-api-key ()
+  "Retrieve the saved API key for codeium.com from auth-source."
+  ;; Ensure the auth-source library is loaded
+  (require 'auth-source)
+  (auth-source-pick-first-password :host "codeium.com" :user "apikey"))
+
 (codeium-def codeium/metadata/api_key (_api state)
     (if-let ((api-key (or (codeium-state-last-api-key state) (codeium-get-saved-api-key))))
         (setq codeium/metadata/api_key api-key)


### PR DESCRIPTION
Closes #84

# Demo

## Calling `codeium-init`
![Screenshot 2024-07-31 at 19 04 21](https://github.com/user-attachments/assets/0f44ee9b-fc00-4c31-b975-d6fb30a33268)

## Being prompted for my passphrase to access ~/.authinfo.gpg
![Screenshot 2024-07-31 at 19 04 36](https://github.com/user-attachments/assets/8d242db1-b43b-4d45-973d-8c071b0f6f51)

## Decrypted successfully
![mwXu7](https://github.com/user-attachments/assets/4aab6cb7-56f2-4aed-ae7f-43a5f6a0c832)


## Codeium working
![Screenshot 2024-07-31 at 19 27 26](https://github.com/user-attachments/assets/f22f8e80-dd80-42bb-8f00-0844215f6906)
