### PR TITLE
fix(cape): suggested command does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Here is an example configuration:
     ;; (add-hook 'python-mode-hook
     ;;     (lambda ()
     ;;         (setq-local completion-at-point-functions
-    ;;             (list (cape-super-capf #'codeium-completion-at-point #'lsp-completion-at-point)))))
+    ;;             (list (cape-capf-super #'codeium-completion-at-point #'lsp-completion-at-point)))))
     ;; an async company-backend is coming soon!
 
     ;; codeium-completion-at-point is autoloaded, but you can


### PR DESCRIPTION
The suggested command to add multiple completion with `cape` was wrong. 

It was: `cape-super-capf`

It should be: `cape-capf-super`