### PR TITLE
Add document/absolute_path_migrate_me_to_uri

### DIFF
--- a/codeium.el
+++ b/codeium.el
@@ -317,6 +317,9 @@
     "according to https://www.reddit.com/r/emacs/comments/5b7o9r/elisp_how_to_concat_newline_into_string_regarding/
     this can be always \\n")
 
+(codeium-def codeium/document/absolute_path_migrate_me_to_uri ()
+    (or buffer-file-name (expand-file-name (buffer-name))))
+
 (codeium-def codeium/editor_options/tab_size ()
     tab-width)
 (codeium-def codeium/editor_options/insert_spaces ()


### PR DESCRIPTION
This fixes an error returned when this value is missing:

```
{"code":"unknown","message":"no absolute path"}
```

I had a look at the values the vim plugin sends, and it seems that the value was missing here.

(see https://github.com/Exafunction/codeium.vim/blob/8c01979323b2b480c8bf160d3ff85bd1668baa49/autoload/codeium/doc.vim#L106)
